### PR TITLE
Change certificate entity __init__ and add config file.

### DIFF
--- a/api_calls/crt.py
+++ b/api_calls/crt.py
@@ -2,10 +2,11 @@ import requests
 import json
 import configparser
 
-config = configparser.ConfigParser()
-config.read('prod.conf')
 
 def fetch_certificates_from_domain(domain_name: str) -> dict:
+    config = configparser.ConfigParser()
+    config.read('prod.conf')
+
     http_response = requests.get(
         config.get('crt', 'endpoint_url'),
         params = {

--- a/api_calls/crt.py
+++ b/api_calls/crt.py
@@ -17,4 +17,9 @@ def fetch_certificates_from_domain(domain_name: str) -> dict:
         raise ConnectionError(
             'Status code: {}'.format(http_response.status_code)
         )
+    content_type = http_response.headers.get('Content-Type')
+    if not content_type == 'application/json':
+        raise ValueError(
+            'Expected JSON body. Received: {}'.format(content_type)
+        )
     return json.loads(http_response.text)

--- a/api_calls/crt.py
+++ b/api_calls/crt.py
@@ -1,10 +1,13 @@
 import requests
 import json
+import configparser
 
+config = configparser.ConfigParser()
+config.read('prod.conf')
 
-def fetch_certificates_from_domain(domain_name):
+def fetch_certificates_from_domain(domain_name: str) -> dict:
     http_response = requests.get(
-        'https://crt.sh/',
+        config.get('crt', 'endpoint_url'),
         params = {
             'CN': domain_name,
             'output': 'json'

--- a/custom_entities/custom_entities.py
+++ b/custom_entities/custom_entities.py
@@ -5,33 +5,34 @@ class Certificate(maltego.MaltegoEntity):
     Describes an SSL Certificate as a node in Maltego.
     """
 
-    def __init__(self, cert_id, subject_name,
-                    issuer_name, issuer_id, expiry_date):
-        if not cert_id:
-            raise ValueError('Certificate ID is required.')
-        super().__init__('alexporras.Certificate', cert_id)
+    def __init__(self, certificate: dict):
+        if not 'name_value' in certificate:
+            raise ValueError('Subject CN (name_value) is required.')
+
+        super().__init__(
+            'alexporras.Certificate', certificate.get('name_value'))
         self.addProperty(
             fieldName='certificate_id',
             displayName='Certificate ID',
-            value=cert_id
+            value=certificate.get('id', '')
         )
         self.addProperty(
             fieldName='subject_name',
             displayName='Subject Name',
-            value=subject_name
+            value=certificate.get('name_value')
         )
         self.addProperty(
-            fieldName='issuer_name',
-            displayName='Issuer Name',
-            value=issuer_name
+            fieldName='issuer_dn',
+            displayName='Issuer DN',
+            value=certificate.get('issuer_name', '')
         )
         self.addProperty(
             fieldName='issuer_id',
             displayName='Issuer ID',
-            value=issuer_id
+            value=certificate.get('issuer_ca_id', '')
         )
         self.addProperty(
             fieldName='expiry_date',
             displayName='Expiry Date',
-            value=expiry_date
+            value=certificate.get('not_after', '')
         )

--- a/prod.conf
+++ b/prod.conf
@@ -1,0 +1,2 @@
+[crt]
+endpoint_url=https://crt.sh/

--- a/transforms/CertificateToIssuerName.py
+++ b/transforms/CertificateToIssuerName.py
@@ -1,5 +1,6 @@
 from maltego_trx import entities
 from maltego_trx import transform
+import re
 
 
 class CertificateToIssuerName(transform.DiscoverableTransform):
@@ -9,4 +10,17 @@ class CertificateToIssuerName(transform.DiscoverableTransform):
 
     @classmethod
     def create_entities(cls, request, response):
-        response.addEntity(entities.Phrase, request.getProperty('issuer_name'))
+        issuer_dn = request.getProperty('issuer_dn')
+        match = re.match('.*CN=(.*)', issuer_dn)
+        main_value = issuer_dn if not match else match.group(1)
+        entity = response.addEntity(entities.Phrase, main_value)
+        entity.addProperty(
+            fieldName='issuer_dn',
+            displayName='Issuer DN',
+            value=issuer_dn
+        )
+        entity.addProperty(
+            fieldName='subject_cn',
+            displayName='Subject CN',
+            value=request.getProperty('subject_name')
+        )

--- a/transforms/DomainToCertificates.py
+++ b/transforms/DomainToCertificates.py
@@ -14,18 +14,7 @@ class DomainToCertificates(transform.DiscoverableTransform):
             api_response = crt.fetch_certificates_from_domain(request.Value)
 
             for certificate in api_response:
-                issuer_name = certificate.get('issuer_name', '')
-                match = re.match(r".*CN=(.*)", issuer_name)
-                if match:
-                    issuer_name = match.group(1)
                 response.entities.append(
-                    custom_entities.Certificate(
-                        certificate.get('id', ''),
-                        certificate.get('name_value', ''),
-                        issuer_name,
-                        certificate.get('issuer_ca_id', ''),
-                        certificate.get('not_after', '')
-                    )
-                )
+                    custom_entities.Certificate(certificate))
         except ConnectionError as e:
             response.addUIMessage(str(e))


### PR DESCRIPTION
Certificate entity now receives a dictionary with all the required info.

Hardcoded strings are saved in a config file.