### PR TITLE
Global config and strict matching for Certificates.

### DIFF
--- a/api_calls/crt.py
+++ b/api_calls/crt.py
@@ -3,7 +3,7 @@ import json
 import config
 
 
-def fetch_certificates_from_domain(domain_name: str) -> dict:
+def fetch_certificates_from_domain(domain_name: str) -> list:
     http_response = requests.get(
         config.crt_endpoint_url(),
         params = {

--- a/api_calls/crt.py
+++ b/api_calls/crt.py
@@ -1,26 +1,22 @@
 import requests
 import json
-import configparser
+import config
 
 
 def fetch_certificates_from_domain(domain_name: str) -> dict:
-    config = configparser.ConfigParser()
-    config.read('prod.conf')
-
     http_response = requests.get(
-        config.get('crt', 'endpoint_url'),
+        config.crt_endpoint_url(),
         params = {
             'CN': domain_name,
             'output': 'json'
         }
     )
+
     if not http_response.ok:
         raise ConnectionError(
             'Status code: {}'.format(http_response.status_code)
         )
-    content_type = http_response.headers.get('Content-Type')
-    if not content_type == 'application/json':
-        raise ValueError(
-            'Expected JSON body. Received: {}'.format(content_type)
-        )
+
+    if not http_response.headers.get('Content-Type') == 'application/json':
+        return []
     return json.loads(http_response.text)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,8 @@
+import configparser
+
+
+config = configparser.ConfigParser()
+config.read('prod.conf')
+
+def crt_endpoint_url() -> str:
+    return config.get('crt', 'endpoint_url')

--- a/custom_entities/custom_entities.py
+++ b/custom_entities/custom_entities.py
@@ -14,6 +14,7 @@ class Certificate(maltego.MaltegoEntity):
         self.addProperty(
             fieldName='certificate_id',
             displayName='Certificate ID',
+            matchingRule='strict',
             value=certificate.get('id', '')
         )
         self.addProperty(

--- a/transforms/DomainToCertificates.py
+++ b/transforms/DomainToCertificates.py
@@ -1,7 +1,7 @@
 from api_calls import crt
 from custom_entities import custom_entities
 from maltego_trx import transform
-import re
+
 
 class DomainToCertificates(transform.DiscoverableTransform):
     """


### PR DESCRIPTION
This PR adds the following:

- Certificates are matched strictly by the id.
- Config module that provideds methods to access the config properties.
- Repsonses that are not JSON are considered empty lists.